### PR TITLE
added hotfix for AlienTube extension

### DIFF
--- a/dark_comments.css
+++ b/dark_comments.css
@@ -216,3 +216,8 @@ body
 	color: #ccc !important;
 }
 
+/* Hotfix AlienTube extension */
+section#alientube
+{
+  background-color: #1b1b1b;
+}


### PR DESCRIPTION
changes the background of the comment section of AlienTube (reddit comments for youtube videos) to the color this plugin uses.
might need further fixing like "g+"-button and different comment scores..
