### PR TITLE
Delete popup text color

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -1178,7 +1178,7 @@ section#alientube
 .yt-dialog-fg-content, .yt-uix-overlay-fg-content,
 .yt-dialog-fg, .yt-uix-overlay-fg,
 .overlay-confirmation-preferences-dialog .overlay-confirmation-delivery-method,
-.nbc, .nbc.xta /* Subscription Hover Popup */
+.delete-confirmation-content p, .nbc, .nbc.xta /* Subscription Hover Popup */
 {
 	color: #fff !important;
 	background: #2b2b2b !important;


### PR DESCRIPTION
Currently the popup window when you delete a playlist displays the text as gray with a gray background. Tinkering with the CSS to change the text to white. 