### PR TITLE
Fix YT logo in narrow view

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -20,7 +20,7 @@
 #footer .yt-uix-button-icon-footer-history,
 #footer .yt-uix-button-icon-questionmark,
 .yt-uix-button-icon-report-user, /* About Page Flag */
-#yt-masthead #logo-container .logo, /* YT Logo */
+#yt-masthead #logo-container, /* YT Logo */
 #channel-search .show-search .search-icon, /* Channel Search Button */
 .like-button-renderer-dislike-button:before, /* Dislike Button */
 .like-button-renderer-like-button:before, /* Like Button */


### PR DESCRIPTION
Changes the YT logo shown in narrow view (<=704px) from red-on-white to
gray-on-black.