### PR TITLE
Modified css for the badge that signifies a video is new. Previously …

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -453,6 +453,12 @@ body .yt-uix-button-text[disabled] {
 	color: #888 !important;
 	border: 1px solid #444 !important;
 }
+
+.video-list-item .yt-badge
+{
+  color: #ddd;
+}
+
 /* Video Stats */
 #watch-actions-stats .stats-bragbar
 {


### PR DESCRIPTION
…the badge was illegible as the colors were the same as the dark background. With these styles the badge is now youtube red with white text.

Here are some screenshots to show the differences:

This is how it looks now:
<img width="320" alt="screen shot 2016-04-15 at 13 36 39" src="https://cloud.githubusercontent.com/assets/8471383/14561593/35d4c98c-030f-11e6-8ba7-7ea0e144f16f.png">

This is how it will look with my CSS:
<img width="326" alt="screen shot 2016-04-15 at 13 36 25" src="https://cloud.githubusercontent.com/assets/8471383/14561597/434ef420-030f-11e6-94f8-f8f911d59c6c.png">
